### PR TITLE
更准确的网络丢包数据以及更快的数据收敛

### DIFF
--- a/clients/client-linux.py
+++ b/clients/client-linux.py
@@ -28,6 +28,7 @@ import re
 import os
 import sys
 import json
+import errno
 import subprocess
 import threading
 try:
@@ -181,11 +182,16 @@ def _ping_thread(host, mark, port):
         try:
             b = timeit.default_timer()
             socket.create_connection((IP, port), timeout=1).close()
-            pingTime[mark] = int((timeit.default_timer()-b)*1000)
+            pingTime[mark] = int((timeit.default_timer() - b) * 1000)
             packet_queue.put(1)
-        except:
-            lostPacket += 1
-            packet_queue.put(0)
+        except socket.error as error:
+            if error.errno == errno.ECONNREFUSED:
+                pingTime[mark] = int((timeit.default_timer() - b) * 1000)
+                packet_queue.put(1)
+            #elif error.errno == errno.ETIMEDOUT:
+            else:
+                lostPacket += 1
+                packet_queue.put(0)
 
         if packet_queue.qsize() > 30:
             lostRate[mark] = float(lostPacket) / packet_queue.qsize()

--- a/clients/client-psutil.py
+++ b/clients/client-psutil.py
@@ -168,9 +168,14 @@ def _ping_thread(host, mark, port):
             socket.create_connection((IP, port), timeout=1).close()
             pingTime[mark] = int((timeit.default_timer() - b) * 1000)
             packet_queue.put(1)
-        except:
-            lostPacket += 1
-            packet_queue.put(0)
+        except socket.error as error:
+            if error.errno == errno.ECONNREFUSED:
+                pingTime[mark] = int((timeit.default_timer() - b) * 1000)
+                packet_queue.put(1)
+            #elif error.errno == errno.ETIMEDOUT:
+            else:
+                lostPacket += 1
+                packet_queue.put(0)
 
         if packet_queue.qsize() > 30:
             lostRate[mark] = float(lostPacket) / packet_queue.qsize()

--- a/clients/client-psutil.py
+++ b/clients/client-psutil.py
@@ -15,7 +15,8 @@ USER = "s01"
 PORT = 35601
 PASSWORD = "USER_DEFAULT_PASSWORD"
 INTERVAL = 1
-PORBEPORT = 80
+PROBEPORT = 80
+PROBE_PROTOCOL_PREFER = "ipv4"  # ipv4, ipv6
 PING_PACKET_HISTORY_LEN = 100
 CU = "cu.tz.cloudcpp.com"
 CT = "ct.tz.cloudcpp.com"
@@ -106,7 +107,7 @@ def ip_status():
     ip_check = 0
     for i in [CU, CT, CM]:
         try:
-            socket.create_connection((i, PORBEPORT), timeout=1).close()
+            socket.create_connection((i, PROBEPORT), timeout=1).close()
         except:
             ip_check += 1
     if ip_check >= 2:
@@ -148,13 +149,23 @@ def _ping_thread(host, mark, port):
     lostPacket = 0
     packet_queue = Queue(maxsize=PING_PACKET_HISTORY_LEN)
 
+    IP = host
+    if host.count(':') < 1:     # if not plain ipv6 address, means ipv4 address or hostname
+        try:
+            if PROBE_PROTOCOL_PREFER == 'ipv4':
+                IP = socket.getaddrinfo(host, None, socket.AF_INET)[0][4][0]
+            else:
+                IP = socket.getaddrinfo(host, None, socket.AF_INET6)[0][4][0]
+        except Exception:
+                pass
+
     while True:
         if packet_queue.full():
             if packet_queue.get() == 0:
                 lostPacket -= 1
         try:
             b = timeit.default_timer()
-            socket.create_connection((host, port), timeout=1).close()
+            socket.create_connection((IP, port), timeout=1).close()
             pingTime[mark] = int((timeit.default_timer() - b) * 1000)
             packet_queue.put(1)
         except:
@@ -193,7 +204,7 @@ def get_realtime_date():
         kwargs={
             'host': CU,
             'mark': '10010',
-            'port': PORBEPORT
+            'port': PROBEPORT
         }
     )
     t2 = threading.Thread(
@@ -201,7 +212,7 @@ def get_realtime_date():
         kwargs={
             'host': CT,
             'mark': '189',
-            'port': PORBEPORT
+            'port': PROBEPORT
         }
     )
     t3 = threading.Thread(
@@ -209,7 +220,7 @@ def get_realtime_date():
         kwargs={
             'host': CM,
             'mark': '10086',
-            'port': PORBEPORT
+            'port': PROBEPORT
         }
     )
     t4 = threading.Thread(


### PR DESCRIPTION
1. 修改丢包统计逻辑，只统计最近 N 个包的结果；在网络情况改变的时候，数据可以更快地收敛，准确反映即时网络状况；
2. 可配置丢包统计的时长/数量，默认最近 100 个，用户可修改 PING_PACKET_HISTORY_LEN 值来选择合适的统计时长；
3. 可配置网络测试的 v4/v6 协议优先级，默认 v4 解析优先，用户可修改 PROBE_PROTOCOL_PREFER = "ipv6"