### PR TITLE
改用vnstat作为汇总流量统计工具，优化前端流量显示信息

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,23 @@
-# ServerStatus中文版：   
+参考 [https://github.com/P3TERX/ServerStatus-V](https://github.com/P3TERX/ServerStatus-V) 中 vnstat 统计流量的实现方式，在 [https://github.com/cppla/ServerStatus](https://github.com/cppla/ServerStatus) 的基础上，优化和更新此功能。
+
+使用此版本时注意，需手动安装 vnstat ，如未安装则流量数据不会显示。具体教程请参考：[vnStat 安装教程](https://p3terx.com/archives/statistics-vps-traffic-using-vnstat-under-linux.html)
+
+vnstat 默认以 比特单位  显示， 通过运行以下命令修改/etc/vnstat.conf中的 UnitMode， RateUnit 配置项，以实现 字节单位 显示：
+
+```bash
+# how units are prefixed when traffic is shown
+# 0 = IEC standard prefixes (KiB/MiB/GiB...)
+# 1 = old style binary prefixes (KB/MB/GB...)
+# 2 = SI decimal prefixes (kB/MB/GB...)
+sed -i "s/UnitMode.*/UnitMode 1/g" /etc/vnstat.conf
+
+# used rate unit (0 = bytes, 1 = bits)
+sed -i "s/RateUnit.*/RateUnit 0/g" /etc/vnstat.conf
+```
+
+------
+
+# ServerStatus中文版：
 
 * ServerStatus中文版是一个酷炫高逼格的云探针、云监控、服务器云监控、多服务器探针~。
 * 在线演示：https://tz.cloudcpp.com    
@@ -46,7 +65,7 @@ wget --no-check-certificate -qO client-linux.py 'https://raw.githubusercontent.c
 ```
 
 # 手动安装教程：     
-   
+
 【克隆代码】:
 ```
 git clone https://github.com/cppla/ServerStatus.git

--- a/web/js/serverstatus.js
+++ b/web/js/serverstatus.js
@@ -4,48 +4,58 @@ var d = 0;
 var server_status = new Array();
 
 function timeSince(date) {
-	if(date == 0)
-		return "从未.";
+    if (date == 0) return "从未";
 
-	var seconds = Math.floor((new Date() - date) / 1000);
-	var interval = Math.floor(seconds / 60);
-	if (interval > 1)
-		return interval + " 分钟前.";
-	else
-		return "几秒前.";
+    var seconds = Math.floor((new Date() - date) / 1000);
+    var interval = Math.floor(seconds / 31536000);
+
+    if (interval > 1) return interval + " 年前";
+    interval = Math.floor(seconds / 2592000);
+    if (interval > 1) return interval + " 月前";
+    interval = Math.floor(seconds / 86400);
+    if (interval > 1) return interval + " 日前";
+    interval = Math.floor(seconds / 3600);
+    if (interval > 1) return interval + " 小时前";
+    interval = Math.floor(seconds / 60);
+    if (interval > 1) return interval + " 分钟前";
+    /*if(Math.floor(seconds) >= 5)
+                return Math.floor(seconds) + " seconds";*/
+    else return "刚刚";
 }
 
-function bytesToSize(bytes, precision, si)
-{
-	var ret;
-	si = typeof si !== 'undefined' ? si : 0;
-	if(si != 0) {
-		var megabyte = 1000 * 1000;
-		var gigabyte = megabyte * 1000;
-		var terabyte = gigabyte * 1000;
-	} else {
-		var megabyte = 1024 * 1024;
-		var gigabyte = megabyte * 1024;
-		var terabyte = gigabyte * 1024;
-	}
+function bytesToSize(bytes, precision, si) {
+    var ret;
+    si = typeof si !== "undefined" ? si : 0;
+    if (si != 0) {
+        var kilobyte = 1000;
+        var megabyte = kilobyte * 1000;
+        var gigabyte = megabyte * 1000;
+        var terabyte = gigabyte * 1000;
+    } else {
+        var kilobyte = 1024;
+        var megabyte = kilobyte * 1024;
+        var gigabyte = megabyte * 1024;
+        var terabyte = gigabyte * 1024;
+    }
 
-	if ((bytes >= megabyte) && (bytes < gigabyte)) {
-		ret = (bytes / megabyte).toFixed(precision) + ' M';
-
-	} else if ((bytes >= gigabyte) && (bytes < terabyte)) {
-		ret = (bytes / gigabyte).toFixed(precision) + ' G';
-
-	} else if (bytes >= terabyte) {
-		ret = (bytes / terabyte).toFixed(precision) + ' T';
-
-	} else {
-		return bytes + ' B';
-	}
-	if(si != 0) {
-		return ret + 'B';
-	} else {
-		return ret + 'iB';
-	}
+    if (bytes >= 0 && bytes < kilobyte) {
+        return bytes + " B";
+    } else if (bytes >= kilobyte && bytes < megabyte) {
+        ret = (bytes / kilobyte).toFixed(precision) + " K";
+    } else if (bytes >= megabyte && bytes < gigabyte) {
+        ret = (bytes / megabyte).toFixed(precision) + " M";
+    } else if (bytes >= gigabyte && bytes < terabyte) {
+        ret = (bytes / gigabyte).toFixed(precision) + " G";
+    } else if (bytes >= terabyte) {
+        ret = (bytes / terabyte).toFixed(precision) + " T";
+    } else {
+        return bytes + " B";
+    }
+    if (si != 0) {
+        return ret + "B";
+    } else {
+        return ret + "iB";
+    }
 }
 
 function uptime() {
@@ -176,31 +186,61 @@ function uptime() {
 				    TableRow.children["load"].innerHTML = result.servers[i].load_1.toFixed(2);
 				}
 
-				// Network
-				var netstr = "";
-				if(result.servers[i].network_rx < 1024*1024)
-					netstr += (result.servers[i].network_rx/1024).toFixed(1) + "K";
-				else
-					netstr += (result.servers[i].network_rx/1024/1024).toFixed(1) + "M";
-				netstr += " | "
-				if(result.servers[i].network_tx < 1024*1024)
-					netstr += (result.servers[i].network_tx/1024).toFixed(1) + "K";
-				else
-					netstr += (result.servers[i].network_tx/1024/1024).toFixed(1) + "M";
-				TableRow.children["network"].innerHTML = netstr;
+		                // Network
+		                var netstr = "";
+		                if (result.servers[i].network_rx < 1024)
+		                    netstr += result.servers[i].network_rx.toFixed(0) + "B";
+		                else if (result.servers[i].network_rx < 1024 * 1024)
+		                    netstr += (result.servers[i].network_rx / 1024).toFixed(1) + "K";
+		                else
+		                    netstr +=
+		                    (result.servers[i].network_rx / 1024 / 1024).toFixed(1) + "M";
+		                netstr += " | ";
+		                if (result.servers[i].network_tx < 1024)
+		                    netstr += result.servers[i].network_tx.toFixed(0) + "B";
+		                else if (result.servers[i].network_tx < 1024 * 1024)
+		                    netstr += (result.servers[i].network_tx / 1024).toFixed(1) + "K";
+		                else
+		                    netstr +=
+		                    (result.servers[i].network_tx / 1024 / 1024).toFixed(1) + "M";
+		                TableRow.children["network"].innerHTML = netstr;
 
-				//Traffic
-				var trafficstr = "";
-				if(result.servers[i].network_in < 1024*1024*1024*1024)
-					trafficstr += (result.servers[i].network_in/1024/1024/1024).toFixed(2) + "G";
-                else
-                    trafficstr += (result.servers[i].network_in/1024/1024/1024/1024).toFixed(2) + "T";
-				trafficstr += " | "
-				if(result.servers[i].network_out < 1024*1024*1024*1024)
-				    trafficstr += (result.servers[i].network_out/1024/1024/1024).toFixed(2) + "G";
-				else
-					trafficstr += (result.servers[i].network_out/1024/1024/1024/1024).toFixed(2) + "T";
-				TableRow.children["traffic"].innerHTML = trafficstr;
+		                //Traffic
+		                var trafficstr = "";
+		                if (result.servers[i].network_in < 1024)
+		                    trafficstr += result.servers[i].network_in.toFixed(0) + "B";
+		                else if (result.servers[i].network_in < 1024 * 1024)
+		                    trafficstr += (result.servers[i].network_in / 1024).toFixed(1) + "K";
+		                else if (result.servers[i].network_in < 1024 * 1024 * 1024)
+		                    trafficstr +=
+		                    (result.servers[i].network_in / 1024 / 1024).toFixed(1) + "M";
+		                else if (result.servers[i].network_in < 1024 * 1024 * 1024 * 1024)
+		                    trafficstr +=
+		                    (result.servers[i].network_in / 1024 / 1024 / 1024).toFixed(2) +
+		                    "G";
+		                else
+		                    trafficstr +=
+		                    (result.servers[i].network_in / 1024 / 1024 / 1024 / 1024).toFixed(
+		                        2
+		                    ) + "T";
+		                trafficstr += " | ";
+		                if (result.servers[i].network_out < 1024)
+		                    trafficstr += result.servers[i].network_out.toFixed(0) + "B";
+		                else if (result.servers[i].network_out < 1024 * 1024)
+		                    trafficstr += (result.servers[i].network_out / 1024).toFixed(1) + "K";
+		                else if (result.servers[i].network_out < 1024 * 1024 * 1024)
+		                    trafficstr +=
+		                    (result.servers[i].network_out / 1024 / 1024).toFixed(1) + "M";
+		                else if (result.servers[i].network_out < 1024 * 1024 * 1024 * 1024)
+		                    trafficstr +=
+		                    (result.servers[i].network_out / 1024 / 1024 / 1024).toFixed(2) +
+		                    "G";
+		                else
+		                    trafficstr +=
+		                    (result.servers[i].network_out / 1024 / 1024 / 1024 / 1024).toFixed(
+		                        2
+		                    ) + "T";
+		                TableRow.children["traffic"].innerHTML = trafficstr;
 
 				// CPU
 				if (result.servers[i].cpu >= 90)

--- a/web/js/serverstatus.js
+++ b/web/js/serverstatus.js
@@ -160,21 +160,33 @@ function uptime() {
 					server_status[i] = true;
 				}
 
-				// month traffic
-				var monthtraffic = "";
-				var trafficdiff_in = result.servers[i].network_in - result.servers[i].last_network_in;
-				var trafficdiff_out = result.servers[i].network_out - result.servers[i].last_network_out;
-				if(trafficdiff_in < 1024*1024*1024*1024)
-					monthtraffic += (trafficdiff_in/1024/1024/1024).toFixed(2) + "G";
-				else
-					monthtraffic += (trafficdiff_in/1024/1024/1024/1024).toFixed(2) + "T";
-				monthtraffic += " | "
-				if(trafficdiff_out < 1024*1024*1024*1024)
-					monthtraffic += (trafficdiff_out/1024/1024/1024).toFixed(2) + "G";
-				else
-					monthtraffic += (trafficdiff_out/1024/1024/1024/1024).toFixed(2) + "T";
-				TableRow.children["month_traffic"].children[0].children[0].className = "progress-bar progress-bar-success";
-				TableRow.children["month_traffic"].children[0].children[0].innerHTML = "<small>"+monthtraffic+"</small>";
+                // month traffic
+                var monthtraffic = "";
+                var trafficdiff_in = result.servers[i].network_in - result.servers[i].last_network_in;
+                var trafficdiff_out = result.servers[i].network_out - result.servers[i].last_network_out;
+                if (trafficdiff_in < 1024)
+                    monthtraffic += trafficdiff_in.toFixed(0) + "B";
+                else if (trafficdiff_in < 1024 * 1024)
+                    monthtraffic += (trafficdiff_in / 1024).toFixed(1) + "K";
+                else if (trafficdiff_in < 1024 * 1024 * 1024)
+                    monthtraffic += (trafficdiff_in / 1024 / 1024).toFixed(1) + "M";
+                else if (trafficdiff_in < 1024 * 1024 * 1024 * 1024)
+                    monthtraffic += (trafficdiff_in / 1024 / 1024 / 1024).toFixed(2) + "G";
+                else
+                    monthtraffic += (trafficdiff_in / 1024 / 1024 / 1024 / 1024).toFixed(2) + "T";
+                monthtraffic += " | ";
+                if (trafficdiff_out < 1024)
+                    monthtraffic += trafficdiff_out.toFixed(0) + "B";
+                else if (trafficdiff_out < 1024 * 1024)
+                    monthtraffic += (trafficdiff_out / 1024).toFixed(1) + "K";
+                else if (trafficdiff_out < 1024 * 1024 * 1024)
+                    monthtraffic += (trafficdiff_out / 1024 / 1024).toFixed(1) + "M";
+                else if (trafficdiff_out < 1024 * 1024 * 1024 * 1024)
+                    monthtraffic += (trafficdiff_out / 1024 / 1024 / 1024).toFixed(2) + "G";
+                else
+                    monthtraffic += (trafficdiff_out / 1024 / 1024 / 1024 / 1024).toFixed(2) + "T";
+                TableRow.children["month_traffic"].children[0].children[0].className = "progress-bar progress-bar-success";
+                TableRow.children["month_traffic"].children[0].children[0].innerHTML = "<small>" + monthtraffic + "</small>";
 
 				// Uptime
 				TableRow.children["uptime"].innerHTML = result.servers[i].uptime;


### PR DESCRIPTION
原统计方法在重启后会导致流量信息清零，改用vnstat后可以使流量汇总信息累计计算。