### PR TITLE
修改丢包率分隔符💻为 |

### DIFF
--- a/web/js/serverstatus.js
+++ b/web/js/serverstatus.js
@@ -252,7 +252,7 @@ function uptime() {
                     TableRow.children["ping"].children[0].children[0].className = "progress-bar progress-bar-warning";
                 else
                     TableRow.children["ping"].children[0].children[0].className = "progress-bar progress-bar-success";
-	            TableRow.children["ping"].children[0].children[0].innerHTML = PING_10010 + "%💻" + PING_189 + "%💻" + PING_10086 + "%";
+	            TableRow.children["ping"].children[0].children[0].innerHTML = PING_10010 + "% | " + PING_189 + "% | " + PING_10086 + "%";
 
 				// Custom
 				if (result.servers[i].custom) {


### PR DESCRIPTION
💻太占空间，导致当丢包率位数较多时，无法正常显示全部数字