### PR TITLE
Revert "修改丢包率分隔符💻为 |"

### DIFF
--- a/web/js/serverstatus.js
+++ b/web/js/serverstatus.js
@@ -252,7 +252,7 @@ function uptime() {
                     TableRow.children["ping"].children[0].children[0].className = "progress-bar progress-bar-warning";
                 else
                     TableRow.children["ping"].children[0].children[0].className = "progress-bar progress-bar-success";
-	            TableRow.children["ping"].children[0].children[0].innerHTML = PING_10010 + "% | " + PING_189 + "% | " + PING_10086 + "%";
+	            TableRow.children["ping"].children[0].children[0].innerHTML = PING_10010 + "%💻" + PING_189 + "%💻" + PING_10086 + "%";
 
 				// Custom
 				if (result.servers[i].custom) {


### PR DESCRIPTION
Reverts cppla/ServerStatus#135

当节点名和位置命名过长，引起丢包率显示不全，换成间隔符是伪命题
<img width="1126" alt="截屏2022-03-02 下午6 47 07" src="https://user-images.githubusercontent.com/10623809/156347703-9c647eec-67f3-4a23-bc0e-e45a5a603d12.png">

