### PR TITLE
Update Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ RUN make -j
 RUN pwd && ls -a
 
 # glibc env run
-FROM nginx:latest
+FROM nginx:1.19
 
 RUN mkdir -p /ServerStatus/server/ && ln -sf /dev/null /var/log/nginx/access.log && ln -sf /dev/null /var/log/nginx/error.log
 


### PR DESCRIPTION
修改 Dokcerfile Nginx镜像版本，否则由于镜像源的问题会出不兼容的的报错

 => ERROR [serverstatus stage-1 2/5] RUN mkdir -p /ServerStatus/server/ && ln -sf /dev/null /var/log/nginx/access.log && ln -sf /dev/nul  0.1s
 => CANCELED [serverstatus builder 2/6] RUN apt-get update -y && apt-get -y install gcc g++ make libcurl4-openssl-dev                     0.0s
------
 > [serverstatus stage-1 2/5] RUN mkdir -p /ServerStatus/server/ && ln -sf /dev/null /var/log/nginx/access.log && ln -sf /dev/null /var/log/nginx/error.log:
0.042 ln: failed to access '/var/log/nginx/access.log/null': Not a directory
