### PR TITLE
fix(web): 表头三态排序 + 升序箭头高亮修复

### DIFF
--- a/web/css/app.css
+++ b/web/css/app.css
@@ -294,7 +294,7 @@ body.light .cards .card-spec-chip{background:color-mix(in srgb,var(--accent) 8%,
 .danger-btn:hover{background:var(--danger);color:#fff}
 th[data-sort]{cursor:pointer;user-select:none}
 th[data-sort]:after{content:"";display:inline-block;margin-left:6px;border:4px solid transparent;border-top-color:color-mix(in srgb,var(--text-dim) 70%,transparent);transform:translateY(2px);opacity:.45}
-th[data-sort].sorted-asc:after{border-top-color:transparent;border-bottom-color:var(--accent);transform:translateY(-2px)}
+th[data-sort].sorted-asc:after{border-top-color:transparent;border-bottom-color:var(--accent);transform:translateY(-2px);opacity:1}
 th[data-sort].sorted-desc:after{border-top-color:var(--accent);opacity:1}
 .section-head h2{margin:0;font-size:18px}
 .section-head p{margin:.25rem 0 0}

--- a/web/js/app.js
+++ b/web/js/app.js
@@ -512,6 +512,7 @@ function renderServers(){
   document.querySelectorAll('#serversTable th[data-sort]').forEach(th => {
     th.classList.toggle('sorted-asc', th.dataset.sort === S.filters.sort && S.filters.dir === 'asc');
     th.classList.toggle('sorted-desc', th.dataset.sort === S.filters.sort && S.filters.dir === 'desc');
+    th.title = '点击排序：升序 → 降序 → 恢复配置顺序';
   });
   if(!rows.length){
     if(tbody.dataset.empty !== 'servers'){
@@ -778,8 +779,13 @@ function bindFilters(){
     renderServersViewNow();
   });
   document.querySelectorAll('#serversTable th[data-sort]').forEach(th => th.addEventListener('click', () => {
-    if(S.filters.sort === th.dataset.sort) S.filters.dir = S.filters.dir === 'desc' ? 'asc' : 'desc';
-    else S.filters.sort = th.dataset.sort;
+    if(S.filters.sort !== th.dataset.sort) {
+      S.filters.sort = th.dataset.sort; S.filters.dir = 'asc';
+    } else if(S.filters.dir === 'asc') {
+      S.filters.dir = 'desc';
+    } else {
+      S.filters.sort = 'config'; S.filters.dir = 'asc';
+    }
     syncSortControls();
     saveSortPreference();
     renderServersViewNow();


### PR DESCRIPTION
## 问题

节点 ≤10 时，带排序下拉框的工具栏被隐藏，但点击表头排序仍可用——**排序后无法恢复"配置顺序"**（唯一恢复入口被隐藏），只能清除 localStorage。另：升序箭头漏写 `opacity:1`，继承基础态 `.45`，与降序高亮不一致。

## 修复

- 表头点击改三态循环：**升序 → 降序 → 恢复配置顺序**（Ant Design / DataTables 标准模式），悬停有提示
- `.sorted-asc` 补 `opacity:1`

## 兼容性

前两次点击行为不变，仅第三次从"回到升序"改为"取消排序"（默认即配置顺序）。

## 演示
<img width="728" height="354" alt="Image" src="https://github.com/user-attachments/assets/4f9d260b-7aff-4765-a360-061f8157a058" />

## 改动
`web/js/app.js`（+8 -2）、`web/css/app.css`（+1 -1）